### PR TITLE
Add clear activity link

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -116,6 +116,15 @@ watch(completedTasks, (newTasks) => {
     }
 
 }, { deep: true }); // Use deep watch for changes within the array/objects
+function clearActivity() {
+  completedTasks.value = [];
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    console.error('Failed to clear tasks from localStorage', e);
+  }
+}
+
 
 
 </script>
@@ -165,6 +174,7 @@ watch(completedTasks, (newTasks) => {
         <ActivityList
           :tasks="completedTasks"
           :total-duration-seconds="totalDurationSeconds"
+          @clear="clearActivity"
         />
       </main>
     </div>

--- a/src/components/ActivityList.vue
+++ b/src/components/ActivityList.vue
@@ -9,6 +9,8 @@ const props = defineProps<{
   totalDurationSeconds: number;
 }>();
 
+const emit = defineEmits(['clear']);
+
 const formattedTotalTime = computed(() => formatSecondsToHHMMSS(props.totalDurationSeconds));
 
 const totalTimeLabel = computed(() => {
@@ -34,6 +36,13 @@ const totalTimeLabel = computed(() => {
       <div>Total</div>
       <div :aria-label="totalTimeLabel">{{ formattedTotalTime }}</div>
     </div>
+
+    <a
+      href="#"
+      class="clear-link"
+      v-if="tasks.length > 0"
+      @click.prevent="emit('clear')"
+    >Clear Activity</a>
   </section>
 </template>
 
@@ -83,5 +92,17 @@ const totalTimeLabel = computed(() => {
     color: var(--color-on-surface);
     font-weight: 500;
     font-variant-numeric: tabular-nums;
+}
+
+.clear-link {
+    margin-top: var(--spacing-small);
+    display: inline-block;
+    color: var(--color-primary);
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.clear-link:hover {
+    text-decoration: none;
 }
 </style>


### PR DESCRIPTION
## Summary
- allow clearing daily activity
- provide a button in ActivityList.vue to clear data
- hook up clearActivity method in App.vue

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cbf7d4098832e932d44400e9c3d2f