### PR TITLE
Add pause/resume feature

### DIFF
--- a/src/components/TaskForm.vue
+++ b/src/components/TaskForm.vue
@@ -190,8 +190,8 @@ function handleKeydown(event: KeyboardEvent) {
 }
 
 .pause-button.pause {
-    background-color: var(--color-surface-variant);
-    color: var(--color-on-surface);
+    background: linear-gradient(45deg, var(--color-warning), var(--color-warning-variant));
+    color: var(--color-on-primary);
 }
 
 .pause-button.resume {

--- a/src/components/TaskForm.vue
+++ b/src/components/TaskForm.vue
@@ -2,13 +2,14 @@
 import { ref, computed } from 'vue';
 
 const taskName = defineModel<string>('taskName', { default: '' });
-const props = defineProps<{ isTracking: boolean }>();
-const emit = defineEmits(['start', 'stop']);
+const props = defineProps<{ isTracking: boolean; isPaused: boolean }>();
+const emit = defineEmits(['start', 'stop', 'pause', 'resume']);
 
 const inputRef = ref<HTMLInputElement | null>(null); // To focus input after stop
 
 const buttonText = computed(() => props.isTracking ? 'Stop Tracking' : 'Start Tracking');
 const buttonClass = computed(() => props.isTracking ? 'action-button tracking' : 'action-button');
+const pauseButtonText = computed(() => props.isPaused ? 'Resume' : 'Pause');
 
 function handleSubmit() {
   // Prevent form submission if used inside a <form> tag
@@ -23,6 +24,14 @@ function handleTrackButtonClick() {
     // Use 'Unnamed Task' if input is empty, trim whitespace
     const nameToTrack = taskName.value.trim() || 'Unnamed Task';
     emit('start', nameToTrack);
+  }
+}
+
+function handlePauseButtonClick() {
+  if (props.isPaused) {
+    emit('resume');
+  } else {
+    emit('pause');
   }
 }
 
@@ -65,6 +74,16 @@ function handleKeydown(event: KeyboardEvent) {
         @click="handleTrackButtonClick"
       >
         {{ buttonText }}
+      </button>
+      <button
+        v-if="isTracking"
+        type="button"
+        id="pauseButton"
+        class="pause-button"
+        :aria-pressed="isPaused"
+        @click="handlePauseButtonClick"
+      >
+        {{ pauseButtonText }}
       </button>
     </form>
   </section>
@@ -153,6 +172,23 @@ function handleKeydown(event: KeyboardEvent) {
 
 .action-button.tracking {
     background: linear-gradient(45deg, var(--color-error), #ff1744);
+}
+
+.pause-button {
+    width: 100%;
+    margin-top: var(--spacing-small);
+    background-color: var(--color-surface-variant);
+    color: var(--color-on-surface);
+    border: none;
+    border-radius: var(--border-radius);
+    padding: var(--spacing-medium);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.pause-button:hover:not(:disabled) {
+    background-color: var(--color-surface-variant-hover, #444);
 }
 
 /* High contrast mode adjustments */

--- a/src/components/TaskForm.vue
+++ b/src/components/TaskForm.vue
@@ -9,7 +9,10 @@ const inputRef = ref<HTMLInputElement | null>(null); // To focus input after sto
 
 const buttonText = computed(() => props.isTracking ? 'Stop Tracking' : 'Start Tracking');
 const buttonClass = computed(() => props.isTracking ? 'action-button tracking' : 'action-button');
-const pauseButtonText = computed(() => props.isPaused ? 'Resume' : 'Pause');
+const pauseButtonText = computed(() => props.isPaused ? 'Resume Tracking' : 'Pause Tracking');
+const pauseButtonClass = computed(() =>
+  props.isPaused ? 'pause-button resume' : 'pause-button pause'
+);
 
 function handleSubmit() {
   // Prevent form submission if used inside a <form> tag
@@ -79,7 +82,7 @@ function handleKeydown(event: KeyboardEvent) {
         v-if="isTracking"
         type="button"
         id="pauseButton"
-        class="pause-button"
+        :class="pauseButtonClass"
         :aria-pressed="isPaused"
         @click="handlePauseButtonClick"
       >
@@ -177,18 +180,27 @@ function handleKeydown(event: KeyboardEvent) {
 .pause-button {
     width: 100%;
     margin-top: var(--spacing-small);
-    background-color: var(--color-surface-variant);
-    color: var(--color-on-surface);
     border: none;
     border-radius: var(--border-radius);
     padding: var(--spacing-medium);
-    font-size: 14px;
+    font-size: 16px;
+    font-weight: 600;
     cursor: pointer;
     transition: background-color 0.3s ease;
 }
 
+.pause-button.pause {
+    background-color: var(--color-surface-variant);
+    color: var(--color-on-surface);
+}
+
+.pause-button.resume {
+    background: linear-gradient(45deg, var(--color-primary), var(--color-primary-variant));
+    color: var(--color-on-primary);
+}
+
 .pause-button:hover:not(:disabled) {
-    background-color: var(--color-surface-variant-hover, #444);
+    filter: brightness(1.1);
 }
 
 /* High contrast mode adjustments */
@@ -212,6 +224,11 @@ function handleKeydown(event: KeyboardEvent) {
         background-color: GrayText;
         border-color: GrayText;
         color: Canvas;
+    }
+    .pause-button {
+        border: 1px solid CanvasText;
+        background: ButtonFace;
+        color: ButtonText;
     }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,8 @@
   --color-surface: rgba(30, 30, 30, 0.7);
   --color-primary: #7c4dff;
   --color-primary-variant: #536dfe;
+  --color-warning: #ff9800;
+  --color-warning-variant: #ffb74d;
   --color-error: #ff5252;
   --color-on-background: #e0e0e0;
   --color-on-surface: #ffffff;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,11 @@
 export interface CurrentTask {
     id: string;
     name: string;
-    startTime: number; // Store as timestamp (Date.now())
-    elapsedSeconds: number;
+    startTime: number; // Timestamp when the task initially started
+    lastResumeTime: number; // Timestamp of the most recent resume
+    elapsedSeconds: number; // Total elapsed time including pauses
+    accumulatedSeconds: number; // Time accumulated before the current session
+    isPaused: boolean;
 }
 
 export interface CompletedTask {


### PR DESCRIPTION
## Summary
- extend task type definitions with pause/resume state
- allow pausing/resuming an active task in the main app logic
- expose new controls in `TaskForm`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684cc02be5a0832ead47d5c7d40db9ce