### PR TITLE
Allow renaming active task

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -71,6 +71,13 @@ function resumeTracking() {
   announceToScreenReader(`Resumed tracking: ${currentTask.value.name}`);
 }
 
+function renameCurrentTask(newName: string) {
+  if (currentTask.value) {
+    currentTask.value.name = newName;
+    announceToScreenReader(`Renamed task to ${newName}`);
+  }
+}
+
 function stopTracking() {
   if (!isTracking.value || !currentTask.value) return; // Prevent stopping if not tracking
 
@@ -205,6 +212,7 @@ function clearActivity() {
           v-if="isTracking && currentTask"
           :task-name="currentTask.name"
           :elapsed-seconds="currentTask.elapsedSeconds"
+          @rename="renameCurrentTask"
         />
 
         <ActivityList

--- a/src/components/ActiveTaskDisplay.vue
+++ b/src/components/ActiveTaskDisplay.vue
@@ -77,6 +77,10 @@ const formattedTime = computed(() => formatSecondsToHHMMSS(props.elapsedSeconds)
     white-space: nowrap;
 }
 
+.active-task-name:has(input) {
+  overflow: visible;
+}
+
 .timer-display {
     /* margin-top: var(--spacing-medium); remove? Already spaced by active-task padding */
     text-align: center;
@@ -88,13 +92,13 @@ const formattedTime = computed(() => formatSecondsToHHMMSS(props.elapsedSeconds)
 }
 
 .rename-input {
-    font-size: 18px;
-    font-weight: 500;
+    font-size: 16px;
+    font-weight: 400;
     color: var(--color-on-surface);
     background-color: transparent;
     border: 1px solid var(--color-surface-variant);
     border-radius: var(--border-radius);
-    padding: 2px 4px;
+    padding: var(--spacing-medium);
     width: 100%;
 }
 

--- a/src/components/ActiveTaskDisplay.vue
+++ b/src/components/ActiveTaskDisplay.vue
@@ -97,4 +97,9 @@ const formattedTime = computed(() => formatSecondsToHHMMSS(props.elapsedSeconds)
     padding: 2px 4px;
     width: 100%;
 }
+
+.rename-input:focus-visible {
+    outline: 3px solid var(--focus-ring-color);
+    outline-offset: 2px;
+}
 </style>

--- a/src/components/ActiveTaskDisplay.vue
+++ b/src/components/ActiveTaskDisplay.vue
@@ -35,6 +35,12 @@ function confirmEdit() {
   isEditing.value = false;
 }
 
+function cancelEdit() {
+  editableName.value = props.taskName;
+  isEditing.value = false;
+}
+        @keydown.space.prevent="cancelEdit"
+
 const formattedTime = computed(() => formatSecondsToHHMMSS(props.elapsedSeconds));
 </script>
 

--- a/src/components/ActiveTaskDisplay.vue
+++ b/src/components/ActiveTaskDisplay.vue
@@ -39,8 +39,7 @@ function cancelEdit() {
   editableName.value = props.taskName;
   isEditing.value = false;
 }
-        @keydown.space.prevent="cancelEdit"
-
+        
 const formattedTime = computed(() => formatSecondsToHHMMSS(props.elapsedSeconds));
 </script>
 
@@ -54,6 +53,7 @@ const formattedTime = computed(() => formatSecondsToHHMMSS(props.elapsedSeconds)
         type="text"
         v-model="editableName"
         @keydown.enter.prevent="confirmEdit"
+        @keydown.escape.prevent="cancelEdit"
         @blur="confirmEdit"
         class="rename-input"
       />

--- a/tests/renameTask.spec.ts
+++ b/tests/renameTask.spec.ts
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import ActiveTaskDisplay from '../src/components/ActiveTaskDisplay.vue'
+
+describe('ActiveTaskDisplay rename', () => {
+  it('emits rename when edited name is submitted with Enter', async () => {
+    const wrapper = mount(ActiveTaskDisplay, {
+      props: {
+        taskName: 'Old Task',
+        elapsedSeconds: 0
+      }
+    })
+
+    await wrapper.get('.active-task-name span').trigger('click')
+    const input = wrapper.get('input.rename-input')
+    await input.setValue('New Task')
+    await input.trigger('keydown.enter')
+
+    expect(wrapper.emitted('rename')).toBeTruthy()
+    expect(wrapper.emitted('rename')![0]).toEqual(['New Task'])
+  })
+})

--- a/tests/renameTask.spec.ts
+++ b/tests/renameTask.spec.ts
@@ -19,4 +19,22 @@ describe('ActiveTaskDisplay rename', () => {
     expect(wrapper.emitted('rename')).toBeTruthy()
     expect(wrapper.emitted('rename')![0]).toEqual(['New Task'])
   })
+
+  it('cancels editing when Space is pressed', async () => {
+    const wrapper = mount(ActiveTaskDisplay, {
+      props: {
+        taskName: 'Old Task',
+        elapsedSeconds: 0
+      }
+    })
+
+    await wrapper.get('.active-task-name span').trigger('click')
+    const input = wrapper.get('input.rename-input')
+    await input.setValue('Changed')
+    await input.trigger('keydown.space')
+
+    expect(wrapper.find('input.rename-input').exists()).toBe(false)
+    expect(wrapper.get('.active-task-name span').text()).toBe('Old Task')
+    expect(wrapper.emitted('rename')).toBeFalsy()
+  })
 })


### PR DESCRIPTION
## Summary
- support editing the active task name
- wire rename event to App state
- test renaming logic

## Testing
- `npx vitest run tests/renameTask.spec.ts --environment jsdom`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cc6fe95b0832e87bad056128efb9a