### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Tempo is a sleek, minimalist time tracking web application designed for professi
 
 ## Design Philosophy
 
-Tempo features a modern dark mode interface with subtle purple accents, designed to reduce eye strain during long work sessions. The minimalist approach ensures that you focus on your work, not on the tool tracking it.
+Tempo features a modern interface with subtle purple accents. A built-in toggle lets you switch between dark and light themes, helping reduce eye strain in any environment. The minimalist approach ensures that you focus on your work, not on the tool tracking it.
 
 ## Accessibility Features
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onBeforeUnmount, watch } from 'vue';
+import { ref, computed, onBeforeUnmount, watch, onMounted } from 'vue';
 import TaskForm from './components/TaskForm.vue';
 import ActiveTaskDisplay from './components/ActiveTaskDisplay.vue';
 import ActivityList from './components/ActivityList.vue';
@@ -12,6 +12,34 @@ const currentTask = ref<CurrentTask | null>(null);
 const completedTasks = ref<CompletedTask[]>([]);
 const timerInterval = ref<number | null>(null);
 const screenReaderAnnouncer = ref<HTMLDivElement | null>(null);
+
+// Theme handling
+const theme = ref<'light' | 'dark'>('dark');
+
+onMounted(() => {
+  const storedTheme = localStorage.getItem('theme');
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    theme.value = storedTheme;
+  }
+  document.documentElement.setAttribute('data-theme', theme.value);
+});
+
+watch(theme, (newTheme) => {
+  document.documentElement.setAttribute('data-theme', newTheme);
+  try {
+    localStorage.setItem('theme', newTheme);
+  } catch (e) {
+    console.error('Failed to save theme to localStorage', e);
+  }
+});
+
+const toggleTheme = () => {
+  theme.value = theme.value === 'dark' ? 'light' : 'dark';
+};
+
+const themeLabel = computed(() =>
+  theme.value === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+);
 
 // Computed Properties
 const isTracking = computed(() => currentTask.value !== null);
@@ -195,6 +223,9 @@ function clearActivity() {
             </svg>
             <h1 class="app-title">Tempo</h1>
         </div>
+        <button class="theme-toggle" @click="toggleTheme" :aria-label="themeLabel">
+          {{ theme === 'dark' ? 'Light' : 'Dark' }} Mode
+        </button>
       </header>
 
       <main>
@@ -248,6 +279,7 @@ function clearActivity() {
     align-items: center;
     justify-content: center; /* Center brand */
     border-bottom: 1px solid var(--color-surface-variant);
+    position: relative;
 }
 
 .brand {
@@ -258,6 +290,22 @@ function clearActivity() {
 
 .logo {
     margin-right: var(--spacing-medium);
+}
+
+.theme-toggle {
+    position: absolute;
+    top: var(--spacing-small);
+    right: var(--spacing-small);
+    background: none;
+    border: none;
+    color: var(--color-on-surface);
+    cursor: pointer;
+    font-size: 14px;
+}
+
+.theme-toggle:focus-visible {
+    outline: 2px solid var(--focus-ring-color);
+    outline-offset: 2px;
 }
 
 .app-title {
@@ -305,6 +353,11 @@ main {
     }
      .logo circle[fill="white"] {
         fill: Canvas; /* Make inner dot background color */
+    }
+    .theme-toggle {
+        color: ButtonText;
+        background: ButtonFace;
+        border: 1px solid ButtonText;
     }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,5 @@
-:root {
+
+:root[data-theme="dark"] {
   --color-background: #121212;
   --color-surface: rgba(30, 30, 30, 0.7);
   --color-primary: #7c4dff;
@@ -16,6 +17,28 @@
   --spacing-small: 8px;
   --spacing-medium: 16px;
   --spacing-large: 24px;
+  --background-gradient: linear-gradient(45deg, #121212 0%, #1e1e1e 100%);
+}
+
+:root[data-theme="light"] {
+  --color-background: #f5f5f5;
+  --color-surface: rgba(255, 255, 255, 0.8);
+  --color-primary: #7c4dff;
+  --color-primary-variant: #536dfe;
+  --color-warning: #ff9800;
+  --color-warning-variant: #ffb74d;
+  --color-error: #ff5252;
+  --color-on-background: #212121;
+  --color-on-surface: #000000;
+  --color-on-primary: #ffffff;
+  --color-on-error: #ffffff;
+  --color-surface-variant: rgba(0, 0, 0, 0.1);
+  --focus-ring-color: rgba(124, 77, 255, 0.5);
+  --border-radius: 8px;
+  --spacing-small: 8px;
+  --spacing-medium: 16px;
+  --spacing-large: 24px;
+  --background-gradient: linear-gradient(45deg, #fafafa 0%, #e0e0e0 100%);
 }
 
 * {
@@ -35,7 +58,7 @@ body {
   align-items: center;
   min-height: 100vh;
   line-height: 1.5;
-  background-image: linear-gradient(45deg, #121212 0%, #1e1e1e 100%);
+  background-image: var(--background-gradient);
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- allow users to switch themes with a new toggle button in the header
- persist selected theme in local storage and apply on load
- provide light and dark CSS variables
- update default html markup and README

## Testing
- `npx vitest run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6851898130b8832e988bc7d367ac0f7b